### PR TITLE
Global discussion re: datagrams (was : 'added C interface to datagram API')

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -161,6 +161,9 @@ void quiche_config_set_ack_delay_exponent(quiche_config *config, uint64_t v);
 // Sets the `max_ack_delay` transport parameter.
 void quiche_config_set_max_ack_delay(quiche_config *config, uint64_t v);
 
+// Sets the `max_datagram_frame_size` transport parameter.
+void quiche_config_set_max_datagram_frame_size(quiche_config *config, uint64_t v);
+
 // Sets the `disable_active_migration` transport parameter.
 void quiche_config_set_disable_active_migration(quiche_config *config, bool v);
 
@@ -230,6 +233,18 @@ ssize_t quiche_conn_stream_recv(quiche_conn *conn, uint64_t stream_id,
 // Writes data to a stream.
 ssize_t quiche_conn_stream_send(quiche_conn *conn, uint64_t stream_id,
                                 const uint8_t *buf, size_t buf_len, bool fin);
+
+// Reads a received datagram
+ssize_t quiche_conn_dgram_recv(quiche_conn *conn, uint8_t **out);
+
+// Frees memory occupied by a received datagram
+void quiche_conn_dgram_free(quiche_conn *conn, uint8_t *dgram,
+                            size_t dgram_len);
+
+// Sends a datagram
+ssize_t quiche_conn_dgram_send(quiche_conn *conn, const uint8_t *buf,
+                               size_t buf_len);
+
 
 enum quiche_shutdown {
     QUICHE_SHUTDOWN_READ = 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1986,7 +1986,7 @@ impl Connection {
 
                     ack_eliciting = true;
                     in_flight = true;
-
+                } else {
                     break;
                 }
             }


### PR DESCRIPTION
As said in https://github.com/cloudflare/quiche/issues/430 I built a small C interop interface on top of the quic datagram's API (no h3).

This PR mostly to discuss it.

Of note: `quiche_conn_dgram_free` is meant to be called to free the buffer returned by `quiche_conn_dgram_recv` which  was allocated "Rust side". Its `_conn` parameter is totally useless, but I kept it there for API uniformity.