### PR TITLE
Fixed a bug in datagram frames when intermixing with streams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1986,7 +1986,7 @@ impl Connection {
 
                     ack_eliciting = true;
                     in_flight = true;
-
+                } else {
                     break;
                 }
             }


### PR DESCRIPTION
This fixes a bug I encountered when sending datagrams inline with standard streams.
What happens (at least, **in my understanding**) is that `send` enters this part:

```
        if pkt_type == packet::Type::Short &&
            left > frame::MAX_DGRAM_OVERHEAD &&
            !is_closing
        {
            while let Some(len) = self.dgram_queue.peek_writable() {
                // Make sure we can fit the data in the packet.
                if left > frame::MAX_DGRAM_OVERHEAD + len {
```

There `left` is > `MAX_DGRAM_OVERHEAD` but less than `MAX_DGRAM_OVERHEAD + len` (which is not known at the `if` line)  and enters an infinite loop. Secondarily, the `break` at the end of the if would've meant that at most one datagram was packed in one frame, even if more than one could fit. 
I moved the break in an `else` branch to fix (hopefully) both.




