### PR TITLE
Fixed a bug in datagram sends where write epoch was not correctly cal…

### DIFF
--- a/src/dgram.rs
+++ b/src/dgram.rs
@@ -90,4 +90,8 @@ impl DatagramQueue {
         // None => Err(Error::Done)
         // }
     }
+
+    pub fn has_pending_writable(&self) -> bool {
+        !self.writable.is_empty()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2876,9 +2876,10 @@ impl Connection {
             }
         }
 
-        // If there are flushable streams, use Application.
+        // If there are flushable streams or datagrams, use Application.
         if self.is_established() &&
             (self.should_update_max_data() ||
+                self.dgram_queue.has_pending_writable() ||
                 self.streams.should_update_max_streams_bidi() ||
                 self.streams.should_update_max_streams_uni() ||
                 self.streams.has_flushable() ||


### PR DESCRIPTION
**Fixed a bug in datagram sends where write epoch was not correctly calculated.**

In my tests, if I started sending datagrams as soon as I've completed the handshake, `Connection::send` returns early without sending any data.

As far as I understand, datagrams should be considered in the calculation of the epoch and bring it to a value of `packet::EPOCH_APPLICATION`; the code is changed so that if a datagram is pending in the writable queue, the `Connection::write_epoch` function returns `packet::EPOCH_APPLICATION` as it does for streams.