### PR TITLE
Fixed app_limited always true when using datagrams

### DIFF
--- a/src/dgram.rs
+++ b/src/dgram.rs
@@ -89,10 +89,4 @@ impl DatagramQueue {
     pub fn pending_bytes(&self) -> usize {
         self.queue_bytes_size
     }
-
-    pub fn purge<F: Fn(&[u8]) -> bool>(&mut self, f: F) {
-        self.queue.retain(|d| !f(d));
-        self.queue_bytes_size = self.queue.iter()
-                                .fold(0, |total, d| total + d.len());
-    }
 }

--- a/src/dgram.rs
+++ b/src/dgram.rs
@@ -29,38 +29,42 @@ use std::collections::VecDeque;
 use crate::Error;
 use crate::Result;
 
-const MAX_FRAME_COUNT: usize = 1000;
+// The default length for datagram frames queues
+const DEFAULT_DGRAM_QUEUE_SIZE: usize = 1000;
 
 /// Keeps track of Datagram frames.
 #[derive(Default)]
 pub struct DatagramQueue {
-    readable: VecDeque<Vec<u8>>,
-    writable: VecDeque<Vec<u8>>,
+    queue: VecDeque<Vec<u8>>,
+    queue_max_len: usize,
+    queue_bytes_size: usize,
 }
 
 impl DatagramQueue {
     pub fn new() -> Self {
         DatagramQueue {
-            readable: VecDeque::new(),
-            writable: VecDeque::new(),
+            queue: VecDeque::new(),
+            queue_bytes_size: 0,
+            queue_max_len: DEFAULT_DGRAM_QUEUE_SIZE,
         }
     }
 
-    fn push(queue: &mut VecDeque<Vec<u8>>, data: &[u8]) -> Result<()> {
-        if queue.len() == MAX_FRAME_COUNT {
+    pub fn push(&mut self, data: &[u8]) -> Result<()> {
+        if self.queue.len() == self.queue_max_len {
             return Err(Error::Done);
         }
 
-        queue.push_back(data.to_vec());
+        self.queue.push_back(data.to_vec());
+        self.queue_bytes_size += data.len();
         Ok(())
     }
 
-    fn peek(queue: &VecDeque<Vec<u8>>) -> Option<usize> {
-        queue.front().map(|d| d.len())
+    pub fn peek(&self) -> Option<usize> {
+        self.queue.front().map(|d| d.len())
     }
 
-    fn pop(queue: &mut VecDeque<Vec<u8>>, buf: &mut [u8]) -> Result<usize> {
-        match queue.front() {
+    pub fn pop(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self.queue.front() {
             Some(d) =>
                 if d.len() > buf.len() {
                     return Err(Error::BufferTooShort);
@@ -69,40 +73,26 @@ impl DatagramQueue {
             None => return Err(Error::Done),
         }
 
-        if let Some(d) = queue.pop_front() {
+        if let Some(d) = self.queue.pop_front() {
             buf[..d.len()].copy_from_slice(&d);
+            self.queue_bytes_size = self.queue_bytes_size.saturating_sub(d.len());
             return Ok(d.len());
         }
 
         Err(Error::Done)
     }
 
-    pub fn push_readable(&mut self, data: &[u8]) -> Result<()> {
-        DatagramQueue::push(&mut self.readable, data)
+    pub fn has_pending(&self) -> bool {
+        !self.queue.is_empty()
     }
 
-    #[allow(dead_code)]
-    pub fn peek_readable(&self) -> Option<usize> {
-        DatagramQueue::peek(&self.readable)
+    pub fn pending_bytes(&self) -> usize {
+        self.queue_bytes_size
     }
 
-    pub fn pop_readable(&mut self, buf: &mut [u8]) -> Result<usize> {
-        DatagramQueue::pop(&mut self.readable, buf)
-    }
-
-    pub fn push_writable(&mut self, data: &[u8]) -> Result<()> {
-        DatagramQueue::push(&mut self.writable, data)
-    }
-
-    pub fn peek_writable(&self) -> Option<usize> {
-        DatagramQueue::peek(&self.writable)
-    }
-
-    pub fn has_writable(&self) -> bool {
-        !&self.writable.is_empty()
-    }
-
-    pub fn pop_writable(&mut self, buf: &mut [u8]) -> Result<usize> {
-        DatagramQueue::pop(&mut self.writable, buf)
+    pub fn purge<F: Fn(&[u8]) -> bool>(&mut self, f: F) {
+        self.queue.retain(|d| !f(d));
+        self.queue_bytes_size = self.queue.iter()
+                                .fold(0, |total, d| total + d.len());
     }
 }

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -808,7 +808,7 @@ impl Connection {
         b.put_varint(flow_id)?;
         b.put_bytes(buf)?;
 
-        conn.dgram_write_queue.push(&d)?;
+        conn.dgram_send_queue.push(&d)?;
 
         Ok(())
     }

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -808,7 +808,7 @@ impl Connection {
         b.put_varint(flow_id)?;
         b.put_bytes(buf)?;
 
-        conn.dgram_writable_queue.push(&d)?;
+        conn.dgram_write_queue.push(&d)?;
 
         Ok(())
     }

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -808,7 +808,7 @@ impl Connection {
         b.put_varint(flow_id)?;
         b.put_bytes(buf)?;
 
-        conn.dgram_queue.push_writable(&d)?;
+        conn.dgram_writable_queue.push(&d)?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -873,8 +873,8 @@ pub struct Connection {
     qlogged_peer_params: bool,
 
     /// Datagram queues.
-    dgram_read_queue: dgram::DatagramQueue,
-    dgram_write_queue: dgram::DatagramQueue,
+    dgram_recv_queue: dgram::DatagramQueue,
+    dgram_send_queue: dgram::DatagramQueue,
 }
 
 /// Creates a new server-side connection.
@@ -1172,8 +1172,8 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlogged_peer_params: false,
 
-            dgram_read_queue: dgram::DatagramQueue::new(),
-            dgram_write_queue: dgram::DatagramQueue::new(),
+            dgram_recv_queue: dgram::DatagramQueue::new(),
+            dgram_send_queue: dgram::DatagramQueue::new(),
         });
 
         if let Some(odcid) = odcid {
@@ -2177,11 +2177,11 @@ impl Connection {
             left > frame::MAX_DGRAM_OVERHEAD &&
             !is_closing
         {
-            while let Some(len) = self.dgram_write_queue.peek() {
+            while let Some(len) = self.dgram_send_queue.peek() {
                 // Make sure we can fit the data in the packet.
                 if left > frame::MAX_DGRAM_OVERHEAD + len {
                     let mut buf = vec![0; len];
-                    match self.dgram_write_queue.pop(&mut buf) {
+                    match self.dgram_send_queue.pop(&mut buf) {
                         Ok(v) => v,
 
                         Err(_) => continue,
@@ -2413,7 +2413,7 @@ impl Connection {
 
         self.sent_count += 1;
 
-        if self.dgram_write_queue.pending_bytes() >
+        if self.dgram_send_queue.pending_bytes() >
             self.recovery.cwnd_available()
         {
             self.recovery.update_app_limited(false);
@@ -2852,7 +2852,7 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn dgram_recv(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let len = self.dgram_read_queue.pop(buf)?;
+        let len = self.dgram_recv_queue.pop(buf)?;
 
         if len > self.local_transport_params.max_datagram_frame_size as usize {
             trace!("received a DATAGRAM larger than max_datagram_frame_size");
@@ -2890,9 +2890,9 @@ impl Connection {
             return Err(Error::BufferTooShort);
         }
 
-        self.dgram_write_queue.push(buf)?;
+        self.dgram_send_queue.push(buf)?;
 
-        if self.dgram_write_queue.pending_bytes() >
+        if self.dgram_send_queue.pending_bytes() >
             self.recovery.cwnd_available()
         {
             self.recovery.update_app_limited(false);
@@ -3175,7 +3175,7 @@ impl Connection {
         if (self.is_established() || self.is_in_early_data()) &&
             (self.should_update_max_data() ||
                 self.blocked_limit.is_some() ||
-                self.dgram_write_queue.has_pending() ||
+                self.dgram_send_queue.has_pending() ||
                 self.streams.should_update_max_streams_bidi() ||
                 self.streams.should_update_max_streams_uni() ||
                 self.streams.has_flushable() ||
@@ -3480,7 +3480,7 @@ impl Connection {
             },
 
             frame::Frame::Datagram { data } => {
-                self.dgram_read_queue.push(&data)?;
+                self.dgram_recv_queue.push(&data)?;
             },
         }
 
@@ -6164,19 +6164,19 @@ mod tests {
         }
 
         assert!(!pipe.client.recovery.app_limited());
-        assert_eq!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
+        assert_eq!(pipe.client.dgram_send_queue.pending_bytes(), 1_000_000);
 
         let len = pipe.client.send(&mut buf).unwrap();
 
-        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 0);
-        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
+        assert_ne!(pipe.client.dgram_send_queue.pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_send_queue.pending_bytes(), 1_000_000);
         assert!(!pipe.client.recovery.app_limited());
 
         testing::recv_send(&mut pipe.client, &mut buf, len).unwrap();
         testing::recv_send(&mut pipe.server, &mut buf, len).unwrap();
 
-        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 0);
-        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
+        assert_ne!(pipe.client.dgram_send_queue.pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_send_queue.pending_bytes(), 1_000_000);
 
         assert!(!pipe.client.recovery.app_limited());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1901,8 +1901,9 @@ impl Connection {
         let pn_len = packet::pkt_num_len(pn)?;
 
         // The AEAD overhead at the current encryption level.
-        let overhead =
-            self.pkt_num_spaces[epoch].overhead().ok_or(Error::Done)?;
+        let crypto_overhead = self.pkt_num_spaces[epoch]
+            .crypto_overhead()
+            .ok_or(Error::Done)?;
 
         let hdr = Header {
             ty: pkt_type,
@@ -1935,16 +1936,30 @@ impl Connection {
 
         hdr.to_bytes(&mut b)?;
 
-        // Make sure we have enough space left for the header, the payload
-        // length, the packet number and the AEAD overhead.
-        left = left
-            .checked_sub(b.off() + pn_len + overhead)
-            .ok_or(Error::Done)?;
+        // Calculate the space required for the packet, including the header
+        // the payload length, the packet number and the AEAD overhead.
+        let mut overhead = b.off() + pn_len + crypto_overhead;
 
         // We assume that the payload length, which is only present in long
         // header packets, can always be encoded with a 2-byte varint.
         if pkt_type != packet::Type::Short {
-            left = left.checked_sub(2).ok_or(Error::Done)?;
+            overhead += 2;
+        }
+
+        // Make sure we have enough space left for the packet.
+        match left.checked_sub(overhead) {
+            Some(v) => left = v,
+
+            None => {
+                // We can't send more because there isn't enough space available
+                // in the output buffer.
+                //
+                // This usually happens when we try to send a new packet but
+                // failed because cwnd is almost full. In such case app_limited
+                // is set to false here to make cwnd grow when ACK is received.
+                self.recovery.update_app_limited(false);
+                return Err(Error::Done);
+            },
         }
 
         let mut frames: Vec<frame::Frame> = Vec::new();
@@ -2266,12 +2281,15 @@ impl Connection {
         }
 
         if frames.is_empty() {
+            // When we reach this point we are not able to write more, so set
+            // app_limited to false.
+            self.recovery.update_app_limited(false);
             return Err(Error::Done);
         }
 
         // Pad the client's initial packet.
         if !self.is_server && pkt_type == packet::Type::Initial {
-            let pkt_len = pn_len + payload_len + overhead;
+            let pkt_len = pn_len + payload_len + crypto_overhead;
 
             let frame = frame::Frame::Padding {
                 len: cmp::min(MIN_CLIENT_INITIAL_LEN - pkt_len, left),
@@ -2297,7 +2315,7 @@ impl Connection {
             in_flight = true;
         }
 
-        payload_len += overhead;
+        payload_len += crypto_overhead;
 
         // Only long header packets have an explicit length field.
         if pkt_type != packet::Type::Short {
@@ -4169,7 +4187,7 @@ pub mod testing {
         hdr.to_bytes(&mut b)?;
 
         let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len()) +
-            space.overhead().unwrap();
+            space.crypto_overhead().unwrap();
 
         if pkt_type != packet::Type::Short {
             let len = pn_len + payload_len;
@@ -5459,7 +5477,7 @@ mod tests {
 
         // Use correct payload length when encrypting the packet.
         let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len()) +
-            space.overhead().unwrap();
+            space.crypto_overhead().unwrap();
 
         let aead = space.crypto_seal.as_ref().unwrap();
 
@@ -5954,6 +5972,153 @@ mod tests {
         assert_eq!(iter.next(), Some(&frame::Frame::Padding { len: 1 }));
 
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn app_limited_true() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(50000);
+        config.set_initial_max_stream_data_bidi_local(50000);
+        config.set_initial_max_stream_data_bidi_remote(50000);
+        config.set_max_packet_size(1200);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_client_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server sends stream data smaller than cwnd.
+        let send_buf = [0; 10000];
+        assert_eq!(pipe.server.stream_send(0, &send_buf, false), Ok(10000));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // app_limited should be true because we send less than cwnd.
+        assert_eq!(pipe.server.recovery.app_limited(), true);
+    }
+
+    #[test]
+    fn app_limited_false() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(50000);
+        config.set_initial_max_stream_data_bidi_local(50000);
+        config.set_initial_max_stream_data_bidi_remote(50000);
+        config.set_max_packet_size(1200);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_client_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server sends stream data bigger than cwnd.
+        let send_buf1 = [0; 20000];
+        assert_eq!(pipe.server.stream_send(0, &send_buf1, false), Ok(14085));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // We can't create a new packet header because there is no room by cwnd.
+        // app_limited should be false because we can't send more by cwnd.
+        assert_eq!(pipe.server.recovery.app_limited(), false);
+    }
+
+    #[test]
+    fn app_limited_false_no_frame() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(50000);
+        config.set_initial_max_stream_data_bidi_local(50000);
+        config.set_initial_max_stream_data_bidi_remote(50000);
+        config.set_max_packet_size(1405);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_client_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server sends stream data bigger than cwnd.
+        let send_buf1 = [0; 20000];
+        assert_eq!(pipe.server.stream_send(0, &send_buf1, false), Ok(14085));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // We can't create a new packet header because there is no room by cwnd.
+        // app_limited should be false because we can't send more by cwnd.
+        assert_eq!(pipe.server.recovery.app_limited(), false);
+    }
+
+    #[test]
+    fn app_limited_false_no_header() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(50000);
+        config.set_initial_max_stream_data_bidi_local(50000);
+        config.set_initial_max_stream_data_bidi_remote(50000);
+        config.set_max_packet_size(1406);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_client_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server sends stream data bigger than cwnd.
+        let send_buf1 = [0; 20000];
+        assert_eq!(pipe.server.stream_send(0, &send_buf1, false), Ok(14085));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // We can't create a new frame because there is no room by cwnd.
+        // app_limited should be false because we can't send more by cwnd.
+        assert_eq!(pipe.server.recovery.app_limited(), false);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -872,8 +872,9 @@ pub struct Connection {
     #[cfg(feature = "qlog")]
     qlogged_peer_params: bool,
 
-    /// Datagram queue.
-    dgram_queue: dgram::DatagramQueue,
+    /// Datagram queues.
+    dgram_readable_queue: dgram::DatagramQueue,
+    dgram_writable_queue: dgram::DatagramQueue,
 }
 
 /// Creates a new server-side connection.
@@ -1171,7 +1172,8 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlogged_peer_params: false,
 
-            dgram_queue: dgram::DatagramQueue::new(),
+            dgram_readable_queue: dgram::DatagramQueue::new(),
+            dgram_writable_queue: dgram::DatagramQueue::new(),
         });
 
         if let Some(odcid) = odcid {
@@ -2175,11 +2177,11 @@ impl Connection {
             left > frame::MAX_DGRAM_OVERHEAD &&
             !is_closing
         {
-            while let Some(len) = self.dgram_queue.peek_writable() {
+            while let Some(len) = self.dgram_writable_queue.peek() {
                 // Make sure we can fit the data in the packet.
                 if left > frame::MAX_DGRAM_OVERHEAD + len {
                     let mut buf = vec![0; len];
-                    match self.dgram_queue.pop_writable(&mut buf) {
+                    match self.dgram_writable_queue.pop(&mut buf) {
                         Ok(v) => v,
 
                         Err(_) => continue,
@@ -2844,7 +2846,7 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn dgram_recv(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let len = self.dgram_queue.pop_readable(buf)?;
+        let len = self.dgram_readable_queue.pop(buf)?;
 
         if len > self.local_transport_params.max_datagram_frame_size as usize {
             trace!("received a DATAGRAM larger than max_datagram_frame_size");
@@ -2882,7 +2884,7 @@ impl Connection {
             return Err(Error::BufferTooShort);
         }
 
-        self.dgram_queue.push_writable(buf)?;
+        self.dgram_writable_queue.push(buf)?;
 
         Ok(())
     }
@@ -3161,7 +3163,7 @@ impl Connection {
         if (self.is_established() || self.is_in_early_data()) &&
             (self.should_update_max_data() ||
                 self.blocked_limit.is_some() ||
-                self.dgram_queue.has_writable() ||
+                self.dgram_writable_queue.has_pending() ||
                 self.streams.should_update_max_streams_bidi() ||
                 self.streams.should_update_max_streams_uni() ||
                 self.streams.has_flushable() ||
@@ -3466,7 +3468,7 @@ impl Connection {
             },
 
             frame::Frame::Datagram { data } => {
-                self.dgram_queue.push_readable(&data)?;
+                self.dgram_readable_queue.push(&data)?;
             },
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -873,8 +873,8 @@ pub struct Connection {
     qlogged_peer_params: bool,
 
     /// Datagram queues.
-    dgram_readable_queue: dgram::DatagramQueue,
-    dgram_writable_queue: dgram::DatagramQueue,
+    dgram_read_queue: dgram::DatagramQueue,
+    dgram_write_queue: dgram::DatagramQueue,
 }
 
 /// Creates a new server-side connection.
@@ -1172,8 +1172,8 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlogged_peer_params: false,
 
-            dgram_readable_queue: dgram::DatagramQueue::new(),
-            dgram_writable_queue: dgram::DatagramQueue::new(),
+            dgram_read_queue: dgram::DatagramQueue::new(),
+            dgram_write_queue: dgram::DatagramQueue::new(),
         });
 
         if let Some(odcid) = odcid {
@@ -2177,11 +2177,11 @@ impl Connection {
             left > frame::MAX_DGRAM_OVERHEAD &&
             !is_closing
         {
-            while let Some(len) = self.dgram_writable_queue.peek() {
+            while let Some(len) = self.dgram_write_queue.peek() {
                 // Make sure we can fit the data in the packet.
                 if left > frame::MAX_DGRAM_OVERHEAD + len {
                     let mut buf = vec![0; len];
-                    match self.dgram_writable_queue.pop(&mut buf) {
+                    match self.dgram_write_queue.pop(&mut buf) {
                         Ok(v) => v,
 
                         Err(_) => continue,
@@ -2413,7 +2413,7 @@ impl Connection {
 
         self.sent_count += 1;
 
-        if self.dgram_writable_queue.pending_bytes() >
+        if self.dgram_write_queue.pending_bytes() >
             self.recovery.cwnd_available()
         {
             self.recovery.update_app_limited(false);
@@ -2852,7 +2852,7 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn dgram_recv(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let len = self.dgram_readable_queue.pop(buf)?;
+        let len = self.dgram_read_queue.pop(buf)?;
 
         if len > self.local_transport_params.max_datagram_frame_size as usize {
             trace!("received a DATAGRAM larger than max_datagram_frame_size");
@@ -2890,9 +2890,9 @@ impl Connection {
             return Err(Error::BufferTooShort);
         }
 
-        self.dgram_writable_queue.push(buf)?;
+        self.dgram_write_queue.push(buf)?;
 
-        if self.dgram_writable_queue.pending_bytes() >
+        if self.dgram_write_queue.pending_bytes() >
             self.recovery.cwnd_available()
         {
             self.recovery.update_app_limited(false);
@@ -3175,7 +3175,7 @@ impl Connection {
         if (self.is_established() || self.is_in_early_data()) &&
             (self.should_update_max_data() ||
                 self.blocked_limit.is_some() ||
-                self.dgram_writable_queue.has_pending() ||
+                self.dgram_write_queue.has_pending() ||
                 self.streams.should_update_max_streams_bidi() ||
                 self.streams.should_update_max_streams_uni() ||
                 self.streams.has_flushable() ||
@@ -3480,7 +3480,7 @@ impl Connection {
             },
 
             frame::Frame::Datagram { data } => {
-                self.dgram_readable_queue.push(&data)?;
+                self.dgram_read_queue.push(&data)?;
             },
         }
 
@@ -6164,19 +6164,19 @@ mod tests {
         }
 
         assert!(!pipe.client.recovery.app_limited());
-        assert_eq!(pipe.client.dgram_writable_queue.pending_bytes(), 1_000_000);
+        assert_eq!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
 
         let len = pipe.client.send(&mut buf).unwrap();
 
-        assert_ne!(pipe.client.dgram_writable_queue.pending_bytes(), 0);
-        assert_ne!(pipe.client.dgram_writable_queue.pending_bytes(), 1_000_000);
+        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
         assert!(!pipe.client.recovery.app_limited());
 
         testing::recv_send(&mut pipe.client, &mut buf, len).unwrap();
         testing::recv_send(&mut pipe.server, &mut buf, len).unwrap();
 
-        assert_ne!(pipe.client.dgram_writable_queue.pending_bytes(), 0);
-        assert_ne!(pipe.client.dgram_writable_queue.pending_bytes(), 1_000_000);
+        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
 
         assert!(!pipe.client.recovery.app_limited());
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -726,7 +726,7 @@ impl PktNumSpace {
         self.ack_elicited = false;
     }
 
-    pub fn overhead(&self) -> Option<usize> {
+    pub fn crypto_overhead(&self) -> Option<usize> {
         Some(self.crypto_seal.as_ref()?.alg().tag_len())
     }
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -638,6 +638,14 @@ impl Recovery {
         )
     }
 
+    pub fn update_app_limited(&mut self, v: bool) {
+        self.app_limited = v;
+    }
+
+    pub fn app_limited(&mut self) -> bool {
+        self.app_limited
+    }
+
     #[cfg(feature = "qlog")]
     pub fn to_qlog(&self) -> qlog::event::Event {
         // QVis can't use all these fields and they can be large.
@@ -739,6 +747,7 @@ impl std::fmt::Debug for Recovery {
         write!(f, "cwnd={} ", self.congestion_window)?;
         write!(f, "ssthresh={} ", self.ssthresh)?;
         write!(f, "bytes_in_flight={} ", self.bytes_in_flight)?;
+        write!(f, "app_limited={} ", self.app_limited)?;
         write!(f, "{:?} ", self.delivery_rate)?;
 
         if self.hystart.enabled() {


### PR DESCRIPTION
This fixes an issue which presents, right now, only with datagrams.

Basically, datagrams have fixed size, there's almost zero chance, unless the application developer is very very precise and cwnd plays right, that the space available in the packet for the datagram frame is exactly the datagram frame size. Most likely there will be space left, but this cause the `(self.bytes_in_flight + sent_bytes) < self.congestion_window` to always fail, and thus recovery will always be in the `app_limited` state.

This works around that, by passing a boolean to `Recovery::on_packet_sent` hinting that more data is available to be sent.
