### PR TITLE
Fixed a bug in datagram sends where write epoch was not correctly calculated.

### DIFF
--- a/src/dgram.rs
+++ b/src/dgram.rs
@@ -98,6 +98,10 @@ impl DatagramQueue {
         DatagramQueue::peek(&self.writable)
     }
 
+    pub fn has_writable(&self) -> bool {
+        !&self.writable.is_empty()
+    }
+
     pub fn pop_writable(&mut self, buf: &mut [u8]) -> Result<usize> {
         DatagramQueue::pop(&mut self.writable, buf)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3143,6 +3143,7 @@ impl Connection {
         if (self.is_established() || self.is_in_early_data()) &&
             (self.should_update_max_data() ||
                 self.blocked_limit.is_some() ||
+                self.dgram_queue.has_writable() ||
                 self.streams.should_update_max_streams_bidi() ||
                 self.streams.should_update_max_streams_uni() ||
                 self.streams.has_flushable() ||


### PR DESCRIPTION
Copy of #6 
I hoped I was able to just resend it after rebase but github broke my PRs when I redid the branch. In any case, I cleaned up the the boringssl bit.

**Fixed a bug in datagram sends where write epoch was not correctly calculated.**

If sending datagrams as soon as I've completed the handshake, `Connection::send` returns early without sending any data; this is due to quiche non entering the `packet::EPOCH_APPLICATION` epoch as `Connection::write_epoch` has no knowledge of datagrams.

The code is changed so that if a datagram is pending in the writable queue, the `Connection::write_epoch` function returns `packet::EPOCH_APPLICATION` as it does for streams.