### PR TITLE
Improved compliance with datagrams IETF draft

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -175,6 +175,9 @@ void quiche_config_set_cc_algorithm(quiche_config *config, enum quiche_cc_algori
 // Configures whether to use HyStart++.
 void quiche_config_enable_hystart(quiche_config *config, bool v);
 
+// Enables support for receiving datagram frames.
+void quiche_config_set_dgram_frames_supported(quiche_config *config, bool v);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 
@@ -330,6 +333,10 @@ typedef struct {
 
 // Collects and returns statistics about the connection.
 void quiche_conn_stats(quiche_conn *conn, quiche_stats *out);
+
+// Gets the size of the largest Datagram payload that can be sent, or
+// QUICHE_ERR_DONE if datagrams cannot be sent on the current connection.
+ssize_t quiche_conn_dgram_max_writable_len(quiche_conn *conn);
 
 // Frees the connection object.
 void quiche_conn_free(quiche_conn *conn);

--- a/src/dgram.rs
+++ b/src/dgram.rs
@@ -50,7 +50,7 @@ impl DatagramQueue {
     }
 
     pub fn push(&mut self, data: &[u8]) -> Result<()> {
-        if self.queue.len() == self.queue_max_len {
+        if self.is_full() {
             return Err(Error::Done);
         }
 
@@ -61,6 +61,13 @@ impl DatagramQueue {
 
     pub fn peek(&self) -> Option<usize> {
         self.queue.front().map(|d| d.len())
+    }
+
+    pub fn discard_front(&mut self) -> Result<()> {
+        match self.queue.pop_front() {
+            None => Err(Error::InvalidState),
+            Some(_) => Ok(())
+        }
     }
 
     pub fn pop(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -84,6 +91,10 @@ impl DatagramQueue {
 
     pub fn has_pending(&self) -> bool {
         !self.queue.is_empty()
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.queue.len() == self.queue_max_len
     }
 
     pub fn pending_bytes(&self) -> usize {

--- a/src/dgram.rs
+++ b/src/dgram.rs
@@ -89,10 +89,4 @@ impl DatagramQueue {
     pub fn pending_bytes(&self) -> usize {
         self.queue_bytes_size
     }
-
-    pub fn purge<F: Fn(&[u8]) -> bool>(&mut self, f: F) {
-        self.queue.retain(|d| !f(d));
-        self.queue_bytes_size = self.queue.iter()
-                                .fold(0, |total, d| total + d.len());
-    }
 }

--- a/src/dgram.rs
+++ b/src/dgram.rs
@@ -29,38 +29,42 @@ use std::collections::VecDeque;
 use crate::Error;
 use crate::Result;
 
-const MAX_FRAME_COUNT: usize = 1000;
+// The default length for datagram frames queues
+const DEFAULT_DGRAM_QUEUE_SIZE: usize = 1000;
 
 /// Keeps track of Datagram frames.
 #[derive(Default)]
 pub struct DatagramQueue {
-    readable: VecDeque<Vec<u8>>,
-    writable: VecDeque<Vec<u8>>,
+    queue: VecDeque<Vec<u8>>,
+    queue_max_len: usize,
+    queue_bytes_size: usize,
 }
 
 impl DatagramQueue {
     pub fn new() -> Self {
         DatagramQueue {
-            readable: VecDeque::new(),
-            writable: VecDeque::new(),
+            queue: VecDeque::new(),
+            queue_bytes_size: 0,
+            queue_max_len: DEFAULT_DGRAM_QUEUE_SIZE,
         }
     }
 
-    fn push(queue: &mut VecDeque<Vec<u8>>, data: &[u8]) -> Result<()> {
-        if queue.len() == MAX_FRAME_COUNT {
+    pub fn push(&mut self, data: &[u8]) -> Result<()> {
+        if self.queue.len() == self.queue_max_len {
             return Err(Error::Done);
         }
 
-        queue.push_back(data.to_vec());
+        self.queue.push_back(data.to_vec());
+        self.queue_bytes_size += data.len();
         Ok(())
     }
 
-    fn peek(queue: &VecDeque<Vec<u8>>) -> Option<usize> {
-        queue.front().map(|d| d.len())
+    pub fn peek(&self) -> Option<usize> {
+        self.queue.front().map(|d| d.len())
     }
 
-    fn pop(queue: &mut VecDeque<Vec<u8>>, buf: &mut [u8]) -> Result<usize> {
-        match queue.front() {
+    pub fn pop(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self.queue.front() {
             Some(d) =>
                 if d.len() > buf.len() {
                     return Err(Error::BufferTooShort);
@@ -69,40 +73,26 @@ impl DatagramQueue {
             None => return Err(Error::Done),
         }
 
-        if let Some(d) = queue.pop_front() {
+        if let Some(d) = self.queue.pop_front() {
             buf[..d.len()].copy_from_slice(&d);
+            self.queue_bytes_size = self.queue_bytes_size.saturating_sub(d.len());
             return Ok(d.len());
         }
 
         Err(Error::Done)
     }
 
-    pub fn push_readable(&mut self, data: &[u8]) -> Result<()> {
-        DatagramQueue::push(&mut self.readable, data)
+    pub fn has_pending(&self) -> bool {
+        !self.queue.is_empty()
     }
 
-    #[allow(dead_code)]
-    pub fn peek_readable(&self) -> Option<usize> {
-        DatagramQueue::peek(&self.readable)
+    pub fn pending_bytes(&self) -> usize {
+        self.queue_bytes_size
     }
 
-    pub fn pop_readable(&mut self, buf: &mut [u8]) -> Result<usize> {
-        DatagramQueue::pop(&mut self.readable, buf)
-    }
-
-    pub fn push_writable(&mut self, data: &[u8]) -> Result<()> {
-        DatagramQueue::push(&mut self.writable, data)
-    }
-
-    pub fn peek_writable(&self) -> Option<usize> {
-        DatagramQueue::peek(&self.writable)
-    }
-
-    pub fn has_writable(&self) -> bool {
-        !&self.writable.is_empty()
-    }
-
-    pub fn pop_writable(&mut self, buf: &mut [u8]) -> Result<usize> {
-        DatagramQueue::pop(&mut self.writable, buf)
+    pub fn purge<F: Fn(&[u8]) -> bool>(&mut self, f: F) {
+        self.queue.retain(|d| !f(d));
+        self.queue_bytes_size = self.queue.iter()
+                                .fold(0, |total, d| total + d.len());
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -259,6 +259,13 @@ pub extern fn quiche_config_enable_hystart(config: &mut Config, v: bool) {
 }
 
 #[no_mangle]
+pub extern fn quiche_config_set_dgram_frames_supported(
+    config: &mut Config, v: bool,
+) {
+    config.set_dgram_frames_supported(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_free(config: *mut Config) {
     unsafe { Box::from_raw(config) };
 }
@@ -667,6 +674,15 @@ pub extern fn quiche_conn_stats(conn: &Connection, out: &mut Stats) {
     out.rtt = stats.rtt.as_nanos() as u64;
     out.cwnd = stats.cwnd;
     out.delivery_rate = stats.delivery_rate;
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_dgram_max_writable_len(conn: &Connection) -> ssize_t {
+    match conn.dgram_max_writable_len() {
+        None => Error::Done.to_c(),
+
+        Some(v) => v as ssize_t,
+    }
 }
 
 #[no_mangle]

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -808,7 +808,7 @@ impl Connection {
         b.put_varint(flow_id)?;
         b.put_bytes(buf)?;
 
-        conn.dgram_write_queue.push(&d)?;
+        conn.dgram_send_queue.push(&d)?;
 
         Ok(())
     }

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -808,7 +808,7 @@ impl Connection {
         b.put_varint(flow_id)?;
         b.put_bytes(buf)?;
 
-        conn.dgram_writable_queue.push(&d)?;
+        conn.dgram_write_queue.push(&d)?;
 
         Ok(())
     }

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -808,7 +808,7 @@ impl Connection {
         b.put_varint(flow_id)?;
         b.put_bytes(buf)?;
 
-        conn.dgram_queue.push_writable(&d)?;
+        conn.dgram_writable_queue.push(&d)?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -873,8 +873,8 @@ pub struct Connection {
     qlogged_peer_params: bool,
 
     /// Datagram queues.
-    dgram_read_queue: dgram::DatagramQueue,
-    dgram_write_queue: dgram::DatagramQueue,
+    dgram_recv_queue: dgram::DatagramQueue,
+    dgram_send_queue: dgram::DatagramQueue,
 }
 
 /// Creates a new server-side connection.
@@ -1172,8 +1172,8 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlogged_peer_params: false,
 
-            dgram_read_queue: dgram::DatagramQueue::new(),
-            dgram_write_queue: dgram::DatagramQueue::new(),
+            dgram_recv_queue: dgram::DatagramQueue::new(),
+            dgram_send_queue: dgram::DatagramQueue::new(),
         });
 
         if let Some(odcid) = odcid {
@@ -2177,11 +2177,11 @@ impl Connection {
             left > frame::MAX_DGRAM_OVERHEAD &&
             !is_closing
         {
-            while let Some(len) = self.dgram_write_queue.peek() {
+            while let Some(len) = self.dgram_send_queue.peek() {
                 // Make sure we can fit the data in the packet.
                 if left > frame::MAX_DGRAM_OVERHEAD + len {
                     let mut buf = vec![0; len];
-                    match self.dgram_write_queue.pop(&mut buf) {
+                    match self.dgram_send_queue.pop(&mut buf) {
                         Ok(v) => v,
 
                         Err(_) => continue,
@@ -2413,7 +2413,7 @@ impl Connection {
 
         self.sent_count += 1;
 
-        if self.dgram_write_queue.pending_bytes() >
+        if self.dgram_send_queue.pending_bytes() >
             self.recovery.cwnd_available()
         {
             self.recovery.update_app_limited(false);
@@ -2852,7 +2852,7 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn dgram_recv(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let len = self.dgram_read_queue.pop(buf)?;
+        let len = self.dgram_recv_queue.pop(buf)?;
 
         if len > self.local_transport_params.max_datagram_frame_size as usize {
             trace!("received a DATAGRAM larger than max_datagram_frame_size");
@@ -2890,9 +2890,9 @@ impl Connection {
             return Err(Error::BufferTooShort);
         }
 
-        self.dgram_write_queue.push(buf)?;
+        self.dgram_send_queue.push(buf)?;
 
-        if self.dgram_write_queue.pending_bytes() >
+        if self.dgram_send_queue.pending_bytes() >
             self.recovery.cwnd_available()
         {
             self.recovery.update_app_limited(false);
@@ -3175,7 +3175,7 @@ impl Connection {
         if (self.is_established() || self.is_in_early_data()) &&
             (self.should_update_max_data() ||
                 self.blocked_limit.is_some() ||
-                self.dgram_write_queue.has_pending() ||
+                self.dgram_send_queue.has_pending() ||
                 self.streams.should_update_max_streams_bidi() ||
                 self.streams.should_update_max_streams_uni() ||
                 self.streams.has_flushable() ||
@@ -3480,7 +3480,7 @@ impl Connection {
             },
 
             frame::Frame::Datagram { data } => {
-                self.dgram_read_queue.push(&data)?;
+                self.dgram_recv_queue.push(&data)?;
             },
         }
 
@@ -6164,19 +6164,19 @@ mod tests {
         }
 
         assert!(!pipe.client.recovery.app_limited());
-        assert_eq!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
+        assert_eq!(pipe.client.dgram_send_queue.pending_bytes(), 1_000_000);
 
         let len = pipe.client.send(&mut buf).unwrap();
 
-        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 0);
-        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
+        assert_ne!(pipe.client.dgram_send_queue.pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_send_queue.pending_bytes(), 1_000_000);
         assert!(!pipe.client.recovery.app_limited());
 
         testing::recv_send(&mut pipe.client, &mut buf, len).unwrap();
         testing::recv_send(&mut pipe.server, &mut buf, len).unwrap();
 
-        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 0);
-        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
+        assert_ne!(pipe.client.dgram_send_queue.pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_send_queue.pending_bytes(), 1_000_000);
 
         assert!(!pipe.client.recovery.app_limited());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1901,8 +1901,9 @@ impl Connection {
         let pn_len = packet::pkt_num_len(pn)?;
 
         // The AEAD overhead at the current encryption level.
-        let overhead =
-            self.pkt_num_spaces[epoch].overhead().ok_or(Error::Done)?;
+        let crypto_overhead = self.pkt_num_spaces[epoch]
+            .crypto_overhead()
+            .ok_or(Error::Done)?;
 
         let hdr = Header {
             ty: pkt_type,
@@ -1935,16 +1936,30 @@ impl Connection {
 
         hdr.to_bytes(&mut b)?;
 
-        // Make sure we have enough space left for the header, the payload
-        // length, the packet number and the AEAD overhead.
-        left = left
-            .checked_sub(b.off() + pn_len + overhead)
-            .ok_or(Error::Done)?;
+        // Calculate the space required for the packet, including the header
+        // the payload length, the packet number and the AEAD overhead.
+        let mut overhead = b.off() + pn_len + crypto_overhead;
 
         // We assume that the payload length, which is only present in long
         // header packets, can always be encoded with a 2-byte varint.
         if pkt_type != packet::Type::Short {
-            left = left.checked_sub(2).ok_or(Error::Done)?;
+            overhead += 2;
+        }
+
+        // Make sure we have enough space left for the packet.
+        match left.checked_sub(overhead) {
+            Some(v) => left = v,
+
+            None => {
+                // We can't send more because there isn't enough space available
+                // in the output buffer.
+                //
+                // This usually happens when we try to send a new packet but
+                // failed because cwnd is almost full. In such case app_limited
+                // is set to false here to make cwnd grow when ACK is received.
+                self.recovery.update_app_limited(false);
+                return Err(Error::Done);
+            },
         }
 
         let mut frames: Vec<frame::Frame> = Vec::new();
@@ -2266,12 +2281,15 @@ impl Connection {
         }
 
         if frames.is_empty() {
+            // When we reach this point we are not able to write more, so set
+            // app_limited to false.
+            self.recovery.update_app_limited(false);
             return Err(Error::Done);
         }
 
         // Pad the client's initial packet.
         if !self.is_server && pkt_type == packet::Type::Initial {
-            let pkt_len = pn_len + payload_len + overhead;
+            let pkt_len = pn_len + payload_len + crypto_overhead;
 
             let frame = frame::Frame::Padding {
                 len: cmp::min(MIN_CLIENT_INITIAL_LEN - pkt_len, left),
@@ -2297,7 +2315,7 @@ impl Connection {
             in_flight = true;
         }
 
-        payload_len += overhead;
+        payload_len += crypto_overhead;
 
         // Only long header packets have an explicit length field.
         if pkt_type != packet::Type::Short {
@@ -4169,7 +4187,7 @@ pub mod testing {
         hdr.to_bytes(&mut b)?;
 
         let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len()) +
-            space.overhead().unwrap();
+            space.crypto_overhead().unwrap();
 
         if pkt_type != packet::Type::Short {
             let len = pn_len + payload_len;
@@ -5459,7 +5477,7 @@ mod tests {
 
         // Use correct payload length when encrypting the packet.
         let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len()) +
-            space.overhead().unwrap();
+            space.crypto_overhead().unwrap();
 
         let aead = space.crypto_seal.as_ref().unwrap();
 
@@ -5954,6 +5972,153 @@ mod tests {
         assert_eq!(iter.next(), Some(&frame::Frame::Padding { len: 1 }));
 
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn app_limited_true() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(50000);
+        config.set_initial_max_stream_data_bidi_local(50000);
+        config.set_initial_max_stream_data_bidi_remote(50000);
+        config.set_max_packet_size(1200);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_client_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server sends stream data smaller than cwnd.
+        let send_buf = [0; 10000];
+        assert_eq!(pipe.server.stream_send(0, &send_buf, false), Ok(10000));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // app_limited should be true because we send less than cwnd.
+        assert_eq!(pipe.server.recovery.app_limited(), true);
+    }
+
+    #[test]
+    fn app_limited_false() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(50000);
+        config.set_initial_max_stream_data_bidi_local(50000);
+        config.set_initial_max_stream_data_bidi_remote(50000);
+        config.set_max_packet_size(1200);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_client_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server sends stream data bigger than cwnd.
+        let send_buf1 = [0; 20000];
+        assert_eq!(pipe.server.stream_send(0, &send_buf1, false), Ok(14085));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // We can't create a new packet header because there is no room by cwnd.
+        // app_limited should be false because we can't send more by cwnd.
+        assert_eq!(pipe.server.recovery.app_limited(), false);
+    }
+
+    #[test]
+    fn app_limited_false_no_frame() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(50000);
+        config.set_initial_max_stream_data_bidi_local(50000);
+        config.set_initial_max_stream_data_bidi_remote(50000);
+        config.set_max_packet_size(1405);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_client_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server sends stream data bigger than cwnd.
+        let send_buf1 = [0; 20000];
+        assert_eq!(pipe.server.stream_send(0, &send_buf1, false), Ok(14085));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // We can't create a new packet header because there is no room by cwnd.
+        // app_limited should be false because we can't send more by cwnd.
+        assert_eq!(pipe.server.recovery.app_limited(), false);
+    }
+
+    #[test]
+    fn app_limited_false_no_header() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(50000);
+        config.set_initial_max_stream_data_bidi_local(50000);
+        config.set_initial_max_stream_data_bidi_remote(50000);
+        config.set_max_packet_size(1406);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_client_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server sends stream data bigger than cwnd.
+        let send_buf1 = [0; 20000];
+        assert_eq!(pipe.server.stream_send(0, &send_buf1, false), Ok(14085));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // We can't create a new frame because there is no room by cwnd.
+        // app_limited should be false because we can't send more by cwnd.
+        assert_eq!(pipe.server.recovery.app_limited(), false);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -872,8 +872,9 @@ pub struct Connection {
     #[cfg(feature = "qlog")]
     qlogged_peer_params: bool,
 
-    /// Datagram queue.
-    dgram_queue: dgram::DatagramQueue,
+    /// Datagram queues.
+    dgram_readable_queue: dgram::DatagramQueue,
+    dgram_writable_queue: dgram::DatagramQueue,
 }
 
 /// Creates a new server-side connection.
@@ -1171,7 +1172,8 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlogged_peer_params: false,
 
-            dgram_queue: dgram::DatagramQueue::new(),
+            dgram_readable_queue: dgram::DatagramQueue::new(),
+            dgram_writable_queue: dgram::DatagramQueue::new(),
         });
 
         if let Some(odcid) = odcid {
@@ -2175,11 +2177,11 @@ impl Connection {
             left > frame::MAX_DGRAM_OVERHEAD &&
             !is_closing
         {
-            while let Some(len) = self.dgram_queue.peek_writable() {
+            while let Some(len) = self.dgram_writable_queue.peek() {
                 // Make sure we can fit the data in the packet.
                 if left > frame::MAX_DGRAM_OVERHEAD + len {
                     let mut buf = vec![0; len];
-                    match self.dgram_queue.pop_writable(&mut buf) {
+                    match self.dgram_writable_queue.pop(&mut buf) {
                         Ok(v) => v,
 
                         Err(_) => continue,
@@ -2844,7 +2846,7 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn dgram_recv(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let len = self.dgram_queue.pop_readable(buf)?;
+        let len = self.dgram_readable_queue.pop(buf)?;
 
         if len > self.local_transport_params.max_datagram_frame_size as usize {
             trace!("received a DATAGRAM larger than max_datagram_frame_size");
@@ -2882,7 +2884,7 @@ impl Connection {
             return Err(Error::BufferTooShort);
         }
 
-        self.dgram_queue.push_writable(buf)?;
+        self.dgram_writable_queue.push(buf)?;
 
         Ok(())
     }
@@ -3161,7 +3163,7 @@ impl Connection {
         if (self.is_established() || self.is_in_early_data()) &&
             (self.should_update_max_data() ||
                 self.blocked_limit.is_some() ||
-                self.dgram_queue.has_writable() ||
+                self.dgram_writable_queue.has_pending() ||
                 self.streams.should_update_max_streams_bidi() ||
                 self.streams.should_update_max_streams_uni() ||
                 self.streams.has_flushable() ||
@@ -3466,7 +3468,7 @@ impl Connection {
             },
 
             frame::Frame::Datagram { data } => {
-                self.dgram_queue.push_readable(&data)?;
+                self.dgram_readable_queue.push(&data)?;
             },
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -873,8 +873,8 @@ pub struct Connection {
     qlogged_peer_params: bool,
 
     /// Datagram queues.
-    dgram_readable_queue: dgram::DatagramQueue,
-    dgram_writable_queue: dgram::DatagramQueue,
+    dgram_read_queue: dgram::DatagramQueue,
+    dgram_write_queue: dgram::DatagramQueue,
 }
 
 /// Creates a new server-side connection.
@@ -1172,8 +1172,8 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlogged_peer_params: false,
 
-            dgram_readable_queue: dgram::DatagramQueue::new(),
-            dgram_writable_queue: dgram::DatagramQueue::new(),
+            dgram_read_queue: dgram::DatagramQueue::new(),
+            dgram_write_queue: dgram::DatagramQueue::new(),
         });
 
         if let Some(odcid) = odcid {
@@ -2177,11 +2177,11 @@ impl Connection {
             left > frame::MAX_DGRAM_OVERHEAD &&
             !is_closing
         {
-            while let Some(len) = self.dgram_writable_queue.peek() {
+            while let Some(len) = self.dgram_write_queue.peek() {
                 // Make sure we can fit the data in the packet.
                 if left > frame::MAX_DGRAM_OVERHEAD + len {
                     let mut buf = vec![0; len];
-                    match self.dgram_writable_queue.pop(&mut buf) {
+                    match self.dgram_write_queue.pop(&mut buf) {
                         Ok(v) => v,
 
                         Err(_) => continue,
@@ -2413,7 +2413,7 @@ impl Connection {
 
         self.sent_count += 1;
 
-        if self.dgram_writable_queue.pending_bytes() >
+        if self.dgram_write_queue.pending_bytes() >
             self.recovery.cwnd_available()
         {
             self.recovery.update_app_limited(false);
@@ -2852,7 +2852,7 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn dgram_recv(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let len = self.dgram_readable_queue.pop(buf)?;
+        let len = self.dgram_read_queue.pop(buf)?;
 
         if len > self.local_transport_params.max_datagram_frame_size as usize {
             trace!("received a DATAGRAM larger than max_datagram_frame_size");
@@ -2890,9 +2890,9 @@ impl Connection {
             return Err(Error::BufferTooShort);
         }
 
-        self.dgram_writable_queue.push(buf)?;
+        self.dgram_write_queue.push(buf)?;
 
-        if self.dgram_writable_queue.pending_bytes() >
+        if self.dgram_write_queue.pending_bytes() >
             self.recovery.cwnd_available()
         {
             self.recovery.update_app_limited(false);
@@ -3175,7 +3175,7 @@ impl Connection {
         if (self.is_established() || self.is_in_early_data()) &&
             (self.should_update_max_data() ||
                 self.blocked_limit.is_some() ||
-                self.dgram_writable_queue.has_pending() ||
+                self.dgram_write_queue.has_pending() ||
                 self.streams.should_update_max_streams_bidi() ||
                 self.streams.should_update_max_streams_uni() ||
                 self.streams.has_flushable() ||
@@ -3480,7 +3480,7 @@ impl Connection {
             },
 
             frame::Frame::Datagram { data } => {
-                self.dgram_readable_queue.push(&data)?;
+                self.dgram_read_queue.push(&data)?;
             },
         }
 
@@ -6164,19 +6164,19 @@ mod tests {
         }
 
         assert!(!pipe.client.recovery.app_limited());
-        assert_eq!(pipe.client.dgram_writable_queue.pending_bytes(), 1_000_000);
+        assert_eq!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
 
         let len = pipe.client.send(&mut buf).unwrap();
 
-        assert_ne!(pipe.client.dgram_writable_queue.pending_bytes(), 0);
-        assert_ne!(pipe.client.dgram_writable_queue.pending_bytes(), 1_000_000);
+        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
         assert!(!pipe.client.recovery.app_limited());
 
         testing::recv_send(&mut pipe.client, &mut buf, len).unwrap();
         testing::recv_send(&mut pipe.server, &mut buf, len).unwrap();
 
-        assert_ne!(pipe.client.dgram_writable_queue.pending_bytes(), 0);
-        assert_ne!(pipe.client.dgram_writable_queue.pending_bytes(), 1_000_000);
+        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_write_queue.pending_bytes(), 1_000_000);
 
         assert!(!pipe.client.recovery.app_limited());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,6 +296,10 @@ const PAYLOAD_MIN_LEN: usize = 20;
 
 const MAX_AMPLIFICATION_FACTOR: usize = 3;
 
+// The datagram standard recommends either none or 65536 as maximum datagram
+// frames size. We enforce the recommendation for forward compatibility.
+const MAX_DGRAM_FRAME_SIZE: u64 = 65536;
+
 /// A specialized [`Result`] type for quiche operations.
 ///
 /// This type is used throughout quiche's public API for any operation that
@@ -721,11 +725,16 @@ impl Config {
         self.cc_algorithm = algo;
     }
 
-    /// Sets the `max_datagram_frame_size` transport parameter.
+    /// Enables support for receiving datagram frames. When enabled, the
+    /// `max_datagram_frame_size` transport parameter is set to 65536 as
+    /// recommended by the current draft of the standard.
     ///
-    /// The default is `0`.
-    pub fn set_max_datagram_frame_size(&mut self, v: u64) {
-        self.local_transport_params.max_datagram_frame_size = v;
+    /// The default is `false`.
+    pub fn set_dgram_frames_supported(&mut self, supported: bool) {
+        self.local_transport_params.max_datagram_frame_size = match supported {
+            true => Some(MAX_DGRAM_FRAME_SIZE),
+            false => None
+        }
     }
 
     /// Configures whether to enable HyStart++.
@@ -1874,21 +1883,8 @@ impl Connection {
 
         let mut left = b.cap();
 
-        // Use max_packet_size as sent by the peer, except during the handshake
-        // when we haven't parsed transport parameters yet, so use a default
-        // value then.
-        let max_pkt_len = if self.is_established() {
-            // We cap the maximum packet size to 16KB or so, so that it can be
-            // always encoded with a 2-byte varint.
-            cmp::min(16383, self.peer_transport_params.max_packet_size) as usize
-        } else {
-            // Allow for 1200 bytes (minimum QUIC packet size) during the
-            // handshake.
-            1200
-        };
-
         // Limit output packet size to respect peer's max_packet_size limit.
-        left = cmp::min(left, max_pkt_len);
+        left = cmp::min(left, self.max_send_packet_len());
 
         // Limit output packet size by congestion window size.
         left = cmp::min(left, self.recovery.cwnd_available());
@@ -2177,27 +2173,32 @@ impl Connection {
             left > frame::MAX_DGRAM_OVERHEAD &&
             !is_closing
         {
-            while let Some(len) = self.dgram_send_queue.peek() {
-                // Make sure we can fit the data in the packet.
-                if left > frame::MAX_DGRAM_OVERHEAD + len {
-                    let mut buf = vec![0; len];
-                    match self.dgram_send_queue.pop(&mut buf) {
-                        Ok(v) => v,
+            if let Some(max_dgram_payload) = self.dgram_max_writable_len() {
+                while let Some(len) = self.dgram_send_queue.peek() {
+                    if (len + frame::MAX_DGRAM_OVERHEAD) <= left {
+                        // Front of the queue fits this packet, send it
+                        let mut buf = vec![0; len];
+                        match self.dgram_send_queue.pop(&mut buf) {
+                            Ok(v) => v,
 
-                        Err(_) => continue,
-                    };
+                            Err(_) => continue,
+                        };
 
-                    let frame = frame::Frame::Datagram { data: buf };
+                        let frame = frame::Frame::Datagram { data: buf };
 
-                    payload_len += frame.wire_len();
-                    left -= frame.wire_len();
+                        payload_len += frame.wire_len();
+                        left -= frame.wire_len();
 
-                    frames.push(frame);
+                        frames.push(frame);
 
-                    ack_eliciting = true;
-                    in_flight = true;
-                } else {
-                    break;
+                        ack_eliciting = true;
+                        in_flight = true;
+                    } else if len > max_dgram_payload {
+                        // this dgram frame will never fit. Let's purge it.
+                        self.dgram_send_queue.discard_front().ok();
+                    } else {
+                        break;
+                    }
                 }
             }
         }
@@ -2439,6 +2440,21 @@ impl Connection {
         }
 
         Ok(written)
+    }
+
+    // Returns the maximum len of a packet to be sent. This is max_packet_size
+    // as sent by the peer, except during the handshake when we haven't parsed
+    // transport parameters yet, so use a default value then.
+    fn max_send_packet_len(&self) -> usize {
+        if self.is_established() {
+            // We cap the maximum packet size to 16KB or so, so that it can be
+            // always encoded with a 2-byte varint.
+            cmp::min(16383, self.peer_transport_params.max_packet_size) as usize
+        } else {
+            // Allow for 1200 bytes (minimum QUIC packet size) during the
+            // handshake.
+            MIN_CLIENT_INITIAL_LEN
+        }
     }
 
     /// Reads contiguous data from a stream into the provided slice.
@@ -2852,25 +2868,25 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn dgram_recv(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let len = self.dgram_recv_queue.pop(buf)?;
-
-        if len > self.local_transport_params.max_datagram_frame_size as usize {
-            trace!("received a DATAGRAM larger than max_datagram_frame_size");
-            return Err(Error::BufferTooShort);
-        }
-
-        Ok(len)
+        Ok(self.dgram_recv_queue.pop(buf)?)
     }
 
     /// Send data in a Datagram frame.
     ///
     /// [`Done`] is returned if no data was written.
+    /// [`InvalidState`] is returned if the peer does not support datagrams.
+    /// [`BufferTooShort`] is returned if the datagram frame length is larger
+    /// than peer's supported datagram frame length. Use
+    /// `peer_datagram_frame_size` to get the largest supported datagram
+    /// frame length.
     ///
     /// Note that there is no flow control of Datagram frames, so in order to
     /// avoid buffering an infinite amount of frames we apply an internal
     /// limit.
     ///
     /// [`Done`]: enum.Error.html#variant.Done
+    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// [`BufferTooShort`]: enum.Error.html#variant.BufferTooShort
     ///
     /// ## Examples:
     ///
@@ -2884,9 +2900,17 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn dgram_send(&mut self, buf: &[u8]) -> Result<()> {
-        if buf.len() > self.peer_transport_params.max_datagram_frame_size as usize
-        {
-            trace!("attempt to send DATAGRAM larger than peer's max_datagram_frame_size");
+        let max_payload_len = match self.dgram_max_writable_len() {
+            Some(v) => v as usize,
+            None => {
+                trace!("attempt to send DATAGRAM to a peer without \
+                        max_datagram_frame_size");
+                return Err(Error::InvalidState);
+            },
+        };
+
+        if buf.len() > max_payload_len {
+            trace!("attempt to send DATAGRAM larger than dgram_max_writable_len");
             return Err(Error::BufferTooShort);
         }
 
@@ -2899,6 +2923,50 @@ impl Connection {
         }
 
         Ok(())
+    }
+
+    /// Gets the size of the largest Datagram frame payload that can be sent,
+    /// given the maximum size supported by the peer, the current maximum
+    /// packet length and the space required by the transport overhead.
+    ///
+    /// [`None`] is returned if the peer hasn't advertised a maximum datagram
+    /// frame size.
+    ///
+    /// ## Examples:
+    ///
+    /// ```no_run
+    /// # let mut buf = [0; 512];
+    /// # let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    /// # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION)?;
+    /// # let scid = [0xba; 16];
+    /// # let mut conn = quiche::accept(&scid, None, &mut config)?;
+    /// if let Some(payload_size) = conn.dgram_max_writable_len() {
+    ///     if payload_size > 5 {
+    ///         conn.dgram_send(b"hello")?;
+    ///     }
+    /// }
+    /// # Ok::<(), quiche::Error>(())
+    /// ```
+    pub fn dgram_max_writable_len(&self) -> Option<usize> {
+        match self.peer_transport_params.max_datagram_frame_size {
+            None => None,
+            Some(peer_frame_len) => {
+                // start from the maximum packet size
+                let mut max_len = self.max_send_packet_len();
+                // subtract the Short packet header overhead
+                // (1 byte of pkt_len + len of dcid)
+                max_len = max_len.saturating_sub(1 + self.dcid.len());
+                // subtract the packet number (max len)
+                max_len = max_len.saturating_sub(packet::MAX_PKT_NUM_LEN);
+                // subtract the crypto overhead
+                max_len = max_len
+                    .saturating_sub(frame::MAX_CRYPTO_OVERHEAD);
+                // clamp to what peer can support
+                max_len = cmp::min(peer_frame_len as usize, max_len);
+                // subtract frame overhead, checked for underflow
+                max_len.checked_sub(frame::MAX_DGRAM_OVERHEAD)
+            }
+        }
     }
 
     /// Returns the amount of time until the next timeout event.
@@ -3480,6 +3548,21 @@ impl Connection {
             },
 
             frame::Frame::Datagram { data } => {
+                // Close the connection if datagrams are not enabled.
+                // quiche always advertises support for 64K sized datagram
+                // frames, as recommended by the standard, so we don't need a
+                // size check.
+                if self.local_transport_params.max_datagram_frame_size.is_none() {
+                    trace!("received a datagram without \
+                            max_datagram_frame_size; closing.");
+                    return Err(Error::InvalidState);
+                }
+
+                // If recv queue is full, discard oldest
+                if self.dgram_recv_queue.is_full() {
+                    self.dgram_recv_queue.discard_front()?;
+                }
+
                 self.dgram_recv_queue.push(&data)?;
             },
         }
@@ -3640,7 +3723,7 @@ struct TransportParams {
     pub disable_active_migration: bool,
     // pub preferred_address: ...,
     pub active_conn_id_limit: u64,
-    pub max_datagram_frame_size: u64,
+    pub max_datagram_frame_size: Option<u64>,
 }
 
 impl Default for TransportParams {
@@ -3660,7 +3743,7 @@ impl Default for TransportParams {
             max_ack_delay: 25,
             disable_active_migration: false,
             active_conn_id_limit: 0,
-            max_datagram_frame_size: 0,
+            max_datagram_frame_size: None,
         }
     }
 }
@@ -3780,7 +3863,7 @@ impl TransportParams {
                 },
 
                 0x0020 => {
-                    tp.max_datagram_frame_size = val.get_varint()?;
+                    tp.max_datagram_frame_size = Some(val.get_varint()?);
                 },
 
                 // Ignore unknown parameters.
@@ -3909,13 +3992,13 @@ impl TransportParams {
             b.put_varint(tp.max_ack_delay)?;
         }
 
-        if tp.max_datagram_frame_size != 0 {
+        if let Some(max_datagram_frame_size) = tp.max_datagram_frame_size {
             TransportParams::encode_param(
                 &mut b,
                 0x0020,
-                octets::varint_len(tp.max_datagram_frame_size),
+                octets::varint_len(max_datagram_frame_size),
             )?;
-            b.put_varint(tp.max_datagram_frame_size)?;
+            b.put_varint(max_datagram_frame_size)?;
         }
 
         if tp.disable_active_migration {
@@ -4293,7 +4376,7 @@ mod tests {
             max_ack_delay: 2_u64.pow(14) - 1,
             disable_active_migration: true,
             active_conn_id_limit: 8,
-            max_datagram_frame_size: 32,
+            max_datagram_frame_size: Some(32),
         };
 
         let mut raw_params = [42; 256];
@@ -4321,7 +4404,7 @@ mod tests {
             max_ack_delay: 2_u64.pow(14) - 1,
             disable_active_migration: true,
             active_conn_id_limit: 8,
-            max_datagram_frame_size: 32,
+            max_datagram_frame_size: Some(32),
         };
 
         let mut raw_params = [42; 256];
@@ -6136,6 +6219,51 @@ mod tests {
     }
 
     #[test]
+    fn dgram_send_fails_invalidstate() {
+        let mut buf = [0; 65535];
+
+        let mut pipe = testing::Pipe::default().unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        assert_eq!(
+            pipe.client.dgram_send(b"hello, world"),
+            Err(Error::InvalidState));
+    }
+
+    #[test]
+    fn dgram_single_datagram() {
+        let mut buf = [0; 65535];
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+
+        config.load_cert_chain_from_pem_file("examples/cert.crt").unwrap();
+        config.load_priv_key_from_pem_file("examples/cert.key").unwrap();
+        config.set_application_protos(b"\x06proto1\x06proto2").unwrap();
+        config.set_initial_max_data(30);
+        config.set_initial_max_stream_data_bidi_local(15);
+        config.set_initial_max_stream_data_bidi_remote(15);
+        config.set_initial_max_stream_data_uni(10);
+        config.set_initial_max_streams_bidi(3);
+        config.set_initial_max_streams_uni(3);
+        config.set_dgram_frames_supported(true);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.dgram_send(b"hello, world"), Ok(()));
+
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        let result = pipe.server.dgram_recv(&mut buf);
+        assert_eq!(result, Ok(12));
+
+        let result = pipe.server.dgram_recv(&mut buf);
+        assert_eq!(result, Err(Error::Done));
+    }
+
+    #[test]
     fn dgram_send_app_limited() {
         let mut buf = [0; 65535];
         let send_buf = [0xcf; 1000];
@@ -6150,7 +6278,7 @@ mod tests {
         config.set_initial_max_stream_data_uni(10);
         config.set_initial_max_streams_bidi(3);
         config.set_initial_max_streams_uni(3);
-        config.set_max_datagram_frame_size(65535);
+        config.set_dgram_frames_supported(true);
         config.set_max_packet_size(1200);
         config.verify_peer(false);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,10 +731,11 @@ impl Config {
     ///
     /// The default is `false`.
     pub fn set_dgram_frames_supported(&mut self, supported: bool) {
-        self.local_transport_params.max_datagram_frame_size = match supported {
-            true => Some(MAX_DGRAM_FRAME_SIZE),
-            false => None
-        }
+        self.local_transport_params.max_datagram_frame_size = if supported {
+            Some(MAX_DGRAM_FRAME_SIZE)
+        } else {
+            None
+        };
     }
 
     /// Configures whether to enable HyStart++.

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -726,7 +726,7 @@ impl PktNumSpace {
         self.ack_elicited = false;
     }
 
-    pub fn overhead(&self) -> Option<usize> {
+    pub fn crypto_overhead(&self) -> Option<usize> {
         Some(self.crypto_seal.as_ref()?.alg().tag_len())
     }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -46,7 +46,7 @@ const PKT_NUM_MASK: u8 = 0x03;
 
 pub const MAX_CID_LEN: u8 = 20;
 
-const MAX_PKT_NUM_LEN: usize = 4;
+pub(crate) const MAX_PKT_NUM_LEN: usize = 4;
 const SAMPLE_LEN: usize = 16;
 
 pub const EPOCH_INITIAL: usize = 0;

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -638,6 +638,14 @@ impl Recovery {
         )
     }
 
+    pub fn update_app_limited(&mut self, v: bool) {
+        self.app_limited = v;
+    }
+
+    pub fn app_limited(&mut self) -> bool {
+        self.app_limited
+    }
+
     #[cfg(feature = "qlog")]
     pub fn to_qlog(&self) -> qlog::event::Event {
         // QVis can't use all these fields and they can be large.
@@ -739,6 +747,7 @@ impl std::fmt::Debug for Recovery {
         write!(f, "cwnd={} ", self.congestion_window)?;
         write!(f, "ssthresh={} ", self.ssthresh)?;
         write!(f, "bytes_in_flight={} ", self.bytes_in_flight)?;
+        write!(f, "app_limited={} ", self.app_limited)?;
         write!(f, "{:?} ", self.delivery_rate)?;
 
         if self.hystart.enabled() {

--- a/tools/apps/src/bin/dgram-client.rs
+++ b/tools/apps/src/bin/dgram-client.rs
@@ -77,9 +77,6 @@ fn main() {
     let max_stream_data = args.get_str("--max-stream-data");
     let max_stream_data = u64::from_str_radix(max_stream_data, 10).unwrap();
 
-    let max_datagram_frame = args.get_str("--max-dgram-frame");
-    let max_datagram_frame = u64::from_str_radix(max_datagram_frame, 10).unwrap();
-
     let version = args.get_str("--wire-version");
     let version = u32::from_str_radix(version, 16).unwrap();
 
@@ -159,7 +156,7 @@ fn main() {
     config.set_initial_max_streams_bidi(app_params.initial_max_streams_bidi);
     config.set_initial_max_streams_uni(app_params.initial_max_streams_uni);
     config.set_disable_active_migration(true);
-    config.set_max_datagram_frame_size(max_datagram_frame);
+    config.set_dgram_frames_supported(true);
 
     let mut http3_conn = None;
 

--- a/tools/apps/src/bin/dgram-server.rs
+++ b/tools/apps/src/bin/dgram-server.rs
@@ -136,7 +136,7 @@ fn main() {
     config.set_initial_max_streams_bidi(max_streams_bidi);
     config.set_initial_max_streams_uni(max_streams_uni);
     config.set_disable_active_migration(true);
-    config.set_max_datagram_frame_size(500);
+    config.set_dgram_frames_supported(true);
 
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();


### PR DESCRIPTION
This PR improves compliancy with the IETF draft of datagrams extensions (a couple commits of other PRs are included because without those, datagrams' unit tests won't work at all).

*(includes #9 because it is required for unit tests in this commit to work)*

### Changes

- `max_datagram_frame_size` becomes an `Option<u64>` (previously was `u64`)
- `dgram_send` now checks that whether the peer advertised `max_datagram_frame_size` and if what it is about to send is greater than the maximum advertised size, and returns `InvalidState` or `BufferTooShort` respectively.
- A `peer_datagram_frame_size` function is available for application to check if datagrams are supported at all
- `dgram_recv` error handling has been moved upstream to `process_frame`
- `process_frame` now drops packets if receive queue is full

### Why

From https://quicwg.org/datagram/draft-ietf-quic-datagram.html#name-transport-parameter :

> An endpoint that receives a DATAGRAM frame when it has not sent the max_datagram_frame_size transport parameter MUST terminate the connection with error PROTOCOL_VIOLATION.

One reason why recv error handling has been moved to `process_frame`.

> An endpoint that receives a DATAGRAM frame that is strictly larger than the value it sent in its max_datagram_frame_size transport parameter MUST terminate the connection with error PROTOCOL_VIOLATION. 

The other reason why recv error handling has been moved to `process_frame`.

> The max_datagram_frame_size transport parameter is an integer value (represented as a variable-length integer) that represents the maximum size of a DATAGRAM frame (including the frame type, length, and payload) the endpoint is willing to receive, in bytes.

Not sure if intended and wildly in "nitpicking" territory here, but a 0 `max_datagram_frame_size` seems to be allowed and would advertise capability to receive 0-length datagrams (presumably, some kind of unreliable ping or whatever). In any case, this the reason why the option moved from `u64` to `Option<u64>`.

> Application protocols that use datagrams MUST define how they react to the max_datagram_frame_size transport parameter being missing. If datagram support is integral to the application, the application protocol can fail the handshake if the max_datagram_frame_size transport parameter is not present.

Now they can query `peer_datagram_frame_size` and decide.

> When a QUIC endpoint receives a valid DATAGRAM frame, it SHOULD deliver the data to the application immediately, as long as it is able to process the frame and can store the contents in memory. 

> The risk associated with not providing flow control for DATAGRAM frames is that a receiver may not be able to commit the necessary resources to process the frames. For example, it may not be able to store the frame contents in memory. However, since DATAGRAM frames are inherently unreliable, they MAY be dropped by the receiver if the receiver cannot process them.

The rationale behind the reason why "`process_frame` now drops packets if receive queue is full" is the two previous points; in this way a peer which cannot keep the pace with datagrams would not starve streams unnecessarily. 
