### PR TITLE
Added C ffi for datagram functions

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -178,6 +178,12 @@ void quiche_config_enable_hystart(quiche_config *config, bool v);
 // Enables support for receiving datagram frames.
 void quiche_config_set_dgram_frames_supported(quiche_config *config, bool v);
 
+// Sets the maximum length of the datagram receive queue.
+void quiche_config_set_dgram_recv_max_queue_len(quiche_config *config, size_t v);
+
+// Sets the maximum length of the datagram send queue.
+void quiche_config_set_dgram_send_max_queue_len(quiche_config *config, size_t v);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 
@@ -337,6 +343,18 @@ void quiche_conn_stats(quiche_conn *conn, quiche_stats *out);
 // Gets the size of the largest Datagram payload that can be sent, or
 // QUICHE_ERR_DONE if datagrams cannot be sent on the current connection.
 ssize_t quiche_conn_dgram_max_writable_len(quiche_conn *conn);
+
+// Reads data from the datagram receive queue.
+ssize_t quiche_conn_dgram_recv(quiche_conn *conn, uint8_t *buf,
+                               size_t buf_len);
+
+// Writes data to the datagram send queue.
+ssize_t quiche_conn_dgram_send(quiche_conn *conn, const uint8_t *buf,
+                               size_t buf_len);
+
+// Iterates over the datagram send queue and purges items matching the predicate.
+void quiche_conn_dgram_purge_outgoing(quiche_conn *conn,
+                                      bool (*f)(uint8_t *, size_t));
 
 // Frees the connection object.
 void quiche_conn_free(quiche_conn *conn);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,7 @@ const PAYLOAD_MIN_LEN: usize = 20;
 
 const MAX_AMPLIFICATION_FACTOR: usize = 3;
 
-// The default length of datagram-frames queues if none is specified in config.
+// The default length of datagram queues if not specified by the user in config.
 const DEFAULT_DGRAM_MAX_QUEUE_LEN: usize = 1000;
 
 // The datagram standard recommends either none or 65536 as maximum datagram


### PR DESCRIPTION
This adds C API for all the datagram functions defined so far (with the lone exception of `quiche_conn_peer_datagram_frame_size` which is defined in #10).