### PR TITLE
Retransmission and reduced memory impact when using datagram frames

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -715,6 +715,13 @@ impl Frame {
         }
     }
 
+    pub fn retransmittable(&self) -> bool {
+        match self {
+            Frame::Datagram { .. } => false,
+            _ => true,
+        }
+    }
+
     #[cfg(feature = "qlog")]
     pub fn to_qlog(&self) -> qlog::QuicFrame {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2410,6 +2410,12 @@ impl Connection {
             aead,
         )?;
 
+        // Once frames have been serialized they are passed to the Recovery
+        // module which manages retransmission. However, some frames are not
+        // retransmittable and storing them is a waste of resources.
+        // So drop them here.
+        frames.retain(|f| f.retransmittable());
+
         let sent_pkt = recovery::Sent {
             pkt_num: pn,
             frames,


### PR DESCRIPTION
Currently recovery keeps a copy in memory of all the frames that must be retransmitted in case of packet loss.

As far as the standard goes, datagram frames should not retransmitted; in addition, keeping a copy of the frames is a memory waste as there's no use in keeping a copy of data which is not going to be retransmitted.

This purges datagram frames just before adding a packet to recovery; this doesn't cause issues to the c.c. because size is calculated and passed separately. There might be better approaches depending on "taste", so this serves also to open the discussion on this point.